### PR TITLE
Update openclaw dependency version to 2026.5.9

### DIFF
--- a/src/bun/RuntimeManager.ts
+++ b/src/bun/RuntimeManager.ts
@@ -287,7 +287,7 @@ export async function installOpenClaw(
         name: "openclaw-runtime",
         version: "1.0.0",
         dependencies: {
-          openclaw: "2026.4.9",
+          openclaw: "2026.5.9",
           // openclaw 内置 Slack 插件的外部依赖，必须安装否则启动报错
           "@slack/web-api": "latest",
           "@slack/bolt": "latest",


### PR DESCRIPTION
Update openclaw dependency version to 2026.5.9